### PR TITLE
fix: fixed go build workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,10 +1,9 @@
 name: Go
 on:
   push:
-    branches: [ master ]
+    tags-ignore:
+      - v*-*-*
   pull_request:
-    branches: [ master ]
-
 jobs:
 
   build:
@@ -12,15 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: '>=1.17.0'
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-        
-      - name: go get
-        run: go get
+        uses: actions/checkout@v2.3.4
 
       - name: Cache go module
         uses: actions/cache@v2
@@ -54,7 +50,7 @@ jobs:
           draft: true
           prerelease: true
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v2.2.1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: build


### PR DESCRIPTION
Fixed inability of a workflow run due to incompatibility according to @ssrlive's build workflow, brought back to the original one, and fixed go runner versions to >=1.17.0 according to the official doc; yet this change will bring up to a new branch for a merged PR used for test releasing and docker image publish, acknowledgment to @toshikijp on pointing out failure on workflow that was showed as a positive working workflow on GitHub

Co-Authored-By: 安田俊樹 (jp) <107352174+toshikijp@users.noreply.github.com>